### PR TITLE
0530 전승준 3문제

### DIFF
--- a/전승준/Week12/BOJ_16174_점프왕_쩰리.java
+++ b/전승준/Week12/BOJ_16174_점프왕_쩰리.java
@@ -1,0 +1,56 @@
+
+package Week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_16174_점프왕_쩰리 {
+	static int[] dr = {0,1};
+	static int[] dc = {1,0};
+	static int[][] MAP;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		MAP = new int[N][N];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) {
+				MAP[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		bfs(0, 0, N);
+	}
+	
+	private static void bfs(int sr, int sc, int N) {
+		Queue<int[]> q = new LinkedList<>();
+		boolean[][] v = new boolean[N][N];
+		q.add(new int[] {sr, sc});
+		v[sr][sc] = true;
+		
+		while(!q.isEmpty()) {
+			int[] poll = q.poll();
+			
+			if(MAP[poll[0]][poll[1]] == -1) {
+				System.out.println("HaruHaru");
+				return;
+			}
+			
+			for(int d=0; d<2; d++) {
+				int nr = poll[0] + MAP[poll[0]][poll[1]] * dr[d];
+				int nc = poll[1] + MAP[poll[0]][poll[1]] * dc[d];
+				
+				if(nr>=0 && nr<N && nc>=0 && nc<N && !v[nr][nc]) {
+					v[nr][nc] = true;
+					q.add(new int[] {nr, nc});
+				}
+			}
+		}
+		System.out.println("Hing");
+	}
+
+}

--- a/전승준/Week12/BOJ_1722_순열의_순서.java
+++ b/전승준/Week12/BOJ_1722_순열의_순서.java
@@ -1,0 +1,67 @@
+package Week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_1722_순열의_순서 {
+	static int CNT, K;
+	static long[] FACTORIAL;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int type = Integer.parseInt(st.nextToken());
+		
+		FACTORIAL = new long[T+1];
+		FACTORIAL[1] = 1;
+		calcFactorial(T);
+		
+		int index = T-1;
+		boolean[] check = new boolean[T+1];
+		
+		if(type == 1) {
+			K = Integer.parseInt(st.nextToken());
+			int[] resArray = new int[T];
+			
+			for(int i=0; i<resArray.length; i++) {
+				int cntNum = 1;
+				
+				for(int j=1; j<=T; j++) {
+					if(K > FACTORIAL[index] && !check[j]) {
+						K -= FACTORIAL[index];
+						cntNum++;
+					}
+				}				
+				System.out.print(cntNum+" ");
+				check[cntNum] = true;
+				index--;
+			}
+		} 
+		else if(type == 2) {
+			long result = 1;
+			
+			for(int seq=0; seq<T; seq++) {
+				int num = Integer.parseInt(st.nextToken());
+
+				for(int i=1; i<=T; i++) {
+					if(i < num && !check[i]) {
+						result += FACTORIAL[index];
+						
+					}
+				}
+				check[num] = true;
+				index--;
+			}
+			System.out.println(result);
+		}
+	}
+
+	private static long calcFactorial(int n) {
+		if(n <= 1) return 1;
+		if(FACTORIAL[n] != 0) return FACTORIAL[n];
+		return FACTORIAL[n] = n * calcFactorial(n-1);
+	}
+
+}

--- a/전승준/Week12/BOJ_1722_순열의_순서.java
+++ b/전승준/Week12/BOJ_1722_순열의_순서.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 public class BOJ_1722_순열의_순서 {
-	static int CNT, K;
 	static long[] FACTORIAL;
 	public static void main(String[] args) throws Exception {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -15,6 +14,7 @@ public class BOJ_1722_순열의_순서 {
 		int type = Integer.parseInt(st.nextToken());
 		
 		FACTORIAL = new long[T+1];
+		FACTORIAL[0] = 1;
 		FACTORIAL[1] = 1;
 		calcFactorial(T);
 		
@@ -22,23 +22,25 @@ public class BOJ_1722_순열의_순서 {
 		boolean[] check = new boolean[T+1];
 		
 		if(type == 1) {
-			K = Integer.parseInt(st.nextToken());
-			int[] resArray = new int[T];
+			long K = Long.parseLong(st.nextToken());
 			
-			for(int i=0; i<resArray.length; i++) {
-				int cntNum = 1;
+			for(int i=0; i<T; i++) {
+				int cnt = 1;
+
+				while(K > FACTORIAL[index]) {
+					K -= FACTORIAL[index];
+					cnt++;
+				}
 				
-				for(int j=1; j<=T; j++) {
-					if(K > FACTORIAL[index] && !check[j]) {
-						K -= FACTORIAL[index];
-						cntNum++;
-					}
-				}				
-				System.out.print(cntNum+" ");
-				check[cntNum] = true;
+				for(int j=1; j<=cnt; j++) {
+					if(check[j]) cnt++;
+				}
+				
+				System.out.print(cnt+" ");
+				check[cnt] = true;
 				index--;
 			}
-		} 
+		}
 		else if(type == 2) {
 			long result = 1;
 			

--- a/전승준/Week12/BOJ_20002_사과나무.java
+++ b/전승준/Week12/BOJ_20002_사과나무.java
@@ -1,0 +1,50 @@
+package Week12;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_20002_사과나무 {
+	static int[] dr = {1,1,0};
+	static int[] dc = {0,1,1};
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int[][] farm = new int[N+1][N+1];
+		int[][] prefixSum = new int[N+1][N+1];
+		int max = -1000;
+		
+		for(int i=1; i<=N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int sum = 0;
+			for(int j=1; j<=N; j++) {
+				farm[i][j] = Integer.parseInt(st.nextToken());
+//				max = Math.max(max, farm[i][j]);
+				sum += farm[i][j];
+				prefixSum[i][j] = sum;
+			}
+		}
+		
+		for(int i=1; i<=N; i++) {
+			int sum = 0;
+			for(int j=1; j<=N; j++) {
+				sum += prefixSum[j][i];
+				prefixSum[j][i] = sum;
+			}
+		}
+
+		for(int i=N; i>=1; i--) {
+			for(int j=N; j>=1; j--) {
+				int maxLength = Math.min(i, j);
+				for(int k=1; k<=maxLength; k++) {
+					int area = prefixSum[i][j] - (prefixSum[i-k][j] + prefixSum[i][j-k]) + prefixSum[i-k][j-k];
+
+					max = Math.max(max, area);
+				}
+			}
+		}
+		
+		System.out.println(max);
+	}
+
+}


### PR DESCRIPTION
[백준] 16174 점프왕 쩰리
* 난이도 : `S1`
* 알고리즘 유형 : `BFS`
* 내용
```
BFS로 구현하는 단순 문제였다. 우측과 하단으로만 이동한다고 해서 방문배열을 안써서 오류가 났었다. 생각해보니 
- 아래->오른쪽
- 오른쪽->아래
이 두가지 케이스만 봐도 겹친다. 수정하고 해결완료!
```
[백준] 1722 순열의 순서
* 난이도 : `G5`
* 알고리즘 유형 : `구현`
* 내용
```
20개의 숫자를 가지고 순열을 구현했더니 시간초과가 났다. 20개 중 20개를 고르는 거면 nPr = 20! = 243경... 으로써
구현하는 문제가 되시겠다!
```
[백준] 20002 사과나무
* 난이도 : `G5`
* 알고리즘 유형 : `누적합`
* 내용
```
2차원 누적합 문제다. 와 누적합을 2차원으로 구현하라니 너무 빡세다!
하지만 계산법을 알고 있으면 나도 누적합고수~
2차원 배열 가로를 쭉 누적해서 각 칸에 넣고, 계산된 값을 세로로 다시 쭉 누적해서 더해놓는다.
이제 누적합 배열 완성!
map(r, c) ~ map(r-n, c-n) 의 누적합을 구하고 싶다면 
map(r, c) - ( map(r-n-1, c) + map(r, c-n-1) ) + map(r-n-1, c-n-1) 을 구하면 된다~
```
