### PR TITLE
0529 송예림 2문제

### DIFF
--- a/송예림/Week12/BOJ_gold5_20002_사과나무.java
+++ b/송예림/Week12/BOJ_gold5_20002_사과나무.java
@@ -1,0 +1,43 @@
+package BAEKJOON;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class gold5_20002_사과나무 {
+	static int[][] map, sum;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int N = Integer.parseInt(br.readLine());
+		map = new int[N+1][N+1];
+		sum = new int[N+1][N+1];
+		
+		for (int r = 1; r < map.length; r++) {
+			st = new StringTokenizer(br.readLine());
+			for (int c = 1; c < map[r].length; c++) {
+				map[r][c] = Integer.parseInt(st.nextToken());
+			}
+		}
+
+		for (int i = 1; i < map.length; i++) {
+			for (int j = 1; j < map[i].length; j++) {
+				sum[i][j] = map[i][j] + sum[i-1][j] + sum[i][j-1] - sum[i-1][j-1];
+			}
+		}
+		
+		int result = sum[1][1];
+		
+		for (int k = 0; k < N; k++) {
+			for (int r = 1; r < N-k+1; r++) {
+				for (int c = 1; c < N-k+1; c++) {
+					int s = sum[r+k][c+k] - sum[r-1][c+k] - sum[r+k][c-1] + sum[r-1][c-1];
+					result = Math.max(result, s);
+				}
+			}
+		}
+		
+		System.out.println(result);
+	}
+
+}

--- a/송예림/Week12/BOJ_silver1_16174_점프왕쩰리_Large.java
+++ b/송예림/Week12/BOJ_silver1_16174_점프왕쩰리_Large.java
@@ -1,0 +1,52 @@
+package BAEKJOON;
+
+import java.io.*;
+import java.util.*;
+
+public class silver1_16174_점프왕쩰리_Large {
+	static int[] dr = {0, 1};
+	static int[] dc = {1, 0};
+	static int N;
+	static int[][] map;
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		for (int r = 0; r < map.length; r++) {
+			st = new StringTokenizer(br.readLine());
+			for (int c = 0; c < map[r].length; c++) {
+				map[r][c] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		System.out.println(bfs(0, 0) ? "HaruHaru" : "Hing");
+	}
+
+	private static boolean bfs(int r, int c) {
+		Queue<int[]> queue = new LinkedList<int[]>();
+		boolean[][] visit = new boolean[N][N];
+		queue.offer(new int[] {r, c});
+		visit[r][c] = true;
+		
+		while(!queue.isEmpty()) {
+			int[] cur = queue.poll();
+			
+			if(cur[0] == N-1 && cur[1] == N-1) {
+				return true;
+			}
+			
+			for (int d = 0; d < dr.length; d++) {
+				int nr = cur[0] + dr[d] * map[cur[0]][cur[1]];
+				int nc = cur[1] + dc[d] * map[cur[0]][cur[1]];
+				if(nr >= 0 && nr < N && nc >= 0 && nc < N && !visit[nr][nc]) {
+					visit[nr][nc] = true;
+					queue.offer(new int[] {nr, nc});
+				}
+			}
+		}
+		
+		return false;
+	}
+}


### PR DESCRIPTION
[BOJ] 16174 점프왕 쩰리 (Large)
* 난이도 : 실버1
* 알고리즘 유형 : bfs
* 내용
```
- 오른쪽, 아래 방향으로만 탐색해서 방문배열 체크 안했더니 메모리 초과났었음
```

[BOJ] 20002 사과나무
* 난이도 : 골드5
* 알고리즘 유형 : 누적합
* 내용
```
- sum[i][j] = map[i][j] + sum[i-1][j] + sum[i][j-1] - sum[i-1][j-1] 로 구간합 구한 후,
- 길이 0부터 N까지 반복하면서 sum[r+k][c+k] - sum[r-1][c+k] - sum[r+k][c-1] + sum[r-1][c-1]로 정사각형 총 이익 구함
- map 길이 N+1 ❗ (0부터 탐색 시작해서 -1 해줘야하니ㄲㅏ...)
- 처음에 그냥 완탐해서 시간초과남
```

[BOJ] 1722 순열의 순서
* 난이도 : 골드5
* 알고리즘 유형 : 
* 내용
```
- 전형적인 순열만드는 dfs 돌렸더니 시간초과
- 아직 해결 못함 ㅠㅠ
```